### PR TITLE
Make QuestRepository return unmodifiable quest set

### DIFF
--- a/server/src/main/java/com/darrenswhite/rs/ironquest/quest/QuestRepository.java
+++ b/server/src/main/java/com/darrenswhite/rs/ironquest/quest/QuestRepository.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -32,7 +33,7 @@ public class QuestRepository {
    */
   public QuestRepository(@Value("${quests.resource}") Resource questsResource,
       ObjectMapper objectMapper) throws IOException {
-    this.quests = load(questsResource, objectMapper);
+    this.quests = Collections.unmodifiableSet(load(questsResource, objectMapper));
   }
 
   public Set<Quest> getQuests() {

--- a/server/src/test/java/com/darrenswhite/rs/ironquest/quest/QuestRepositoryTest.java
+++ b/server/src/test/java/com/darrenswhite/rs/ironquest/quest/QuestRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.darrenswhite.rs.ironquest.player.Skill;
 import com.darrenswhite.rs.ironquest.quest.requirement.CombatRequirement;
@@ -210,6 +211,14 @@ class QuestRepositoryTest {
           .collect(Collectors.toList());
 
       assertThat(quests, containsInAnyOrder(new QuestMatcher(questB), new QuestMatcher(questC)));
+    }
+
+    @Test
+    void shouldReturnUnmodifiableSet() {
+      Set<Quest> loadedQuests = minimalQuestRepository.getQuests();
+      Quest quest = loadedQuests.iterator().next();
+
+      assertThrows(UnsupportedOperationException.class, () -> loadedQuests.add(quest));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary
- Wrap quests with `Collections.unmodifiableSet` so callers cannot modify repository state
- Add unit test ensuring `getQuests` returns an unmodifiable set

## Testing
- `mvn -q test` *(fails: Plugin org.springframework.boot:spring-boot-maven-plugin:3.2.5 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.springframework.boot:spring-boot-maven-plugin:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-maven-plugin:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*