### PR TITLE
Handle missing quests with 404 response

### DIFF
--- a/server/src/main/java/com/darrenswhite/rs/ironquest/path/QuestNotFoundException.java
+++ b/server/src/main/java/com/darrenswhite/rs/ironquest/path/QuestNotFoundException.java
@@ -2,6 +2,8 @@ package com.darrenswhite.rs.ironquest.path;
 
 import com.darrenswhite.rs.ironquest.path.algorithm.PathFinderAlgorithm;
 import com.darrenswhite.rs.ironquest.quest.Quest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
  * Exception thrown when {@link PathFinderAlgorithm} fails to find the next optimal {@link Quest} to
@@ -9,6 +11,7 @@ import com.darrenswhite.rs.ironquest.quest.Quest;
  *
  * @author Darren S. White
  */
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class QuestNotFoundException extends Exception {
 
   public QuestNotFoundException(String message) {

--- a/server/src/test/java/com/darrenswhite/rs/ironquest/controller/QuestControllerTest.java
+++ b/server/src/test/java/com/darrenswhite/rs/ironquest/controller/QuestControllerTest.java
@@ -2,10 +2,17 @@ package com.darrenswhite.rs.ironquest.controller;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.darrenswhite.rs.ironquest.dto.PathDTO;
 import com.darrenswhite.rs.ironquest.dto.PathFinderParametersDTO;
@@ -29,6 +36,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class QuestControllerTest {
 
@@ -114,6 +123,23 @@ class QuestControllerTest {
       verify(pathFinderService).find(player, algorithm);
       verify(path).createDTO();
       assertThat(result, is(pathDTO));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenQuestNotFound() throws Exception {
+      String name = "username";
+      Player player = mock(Player.class);
+
+      when(playerService.createPlayer(anyString(), any(QuestAccessFilter.class),
+          any(QuestTypeFilter.class), anyBoolean(), anyBoolean(), anySet(), anyMap()))
+          .thenReturn(player);
+      when(pathFinderService.find(player, AlgorithmId.DEFAULT))
+          .thenThrow(new QuestNotFoundException("not found"));
+
+      MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+      mockMvc.perform(get("/quests/path").param("name", name))
+          .andExpect(status().isNotFound());
     }
   }
 }


### PR DESCRIPTION
## Summary
- annotate `QuestNotFoundException` with `@ResponseStatus(HttpStatus.NOT_FOUND)`
- test `QuestController` returns 404 when quest lookup fails

## Testing
- `mvn -q test` *(fails: Network is unreachable)*